### PR TITLE
Missing main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
   },
   "bugs" : {
     "url" : "https://github.com/arnklint/node-prowl/issues"
-  }
+  },
+  "main": "./lib/prowl"
 }


### PR DESCRIPTION
Makes require() unable to find module
